### PR TITLE
Add TypeScript devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
 	"homepage": "https://github.com/NativeScript/template-hello-world-ts",
 	"android": {
 		"v8Flags": "--expose_gc"
+	},
+	"devDependencies": {
+		"nativescript-dev-typescript": "^0.2.2"
 	}
 }


### PR DESCRIPTION
In order to enable TypeScript support in NS CLI, you have to execute `tns install typescript`.
This will add two devDependencies in the project. Add nativescript-dev-typescript, so when this template is used, the TypeScript will be enabled by default in the current project.