### PR TITLE
Bumped nativescript-dev-typescript package version to the current 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
 		"v8Flags": "--expose_gc"
 	},
 	"devDependencies": {
-		"nativescript-dev-typescript": "^0.3.0"
+		"nativescript-dev-typescript": "^0.3.2"
 	}
 }


### PR DESCRIPTION
When creating a project using the TypeScript template, an older version of the nativescript-dev-typescript package was being used. This updates the package.json file to use the latest 0.3.2 version